### PR TITLE
Sending boolean in get request

### DIFF
--- a/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
+++ b/src/Illuminate/Validation/Concerns/ValidatesAttributes.php
@@ -435,7 +435,7 @@ trait ValidatesAttributes
      */
     public function validateBoolean($attribute, $value)
     {
-        $acceptable = [true, false, 0, 1, '0', '1'];
+        $acceptable = [true, false, 0, 1, '0', '1', 'true', 'false'];
 
         return in_array($value, $acceptable, true);
     }


### PR DESCRIPTION
When sending get request with:
`&is_user_paid=true`
He wrote `true` as string, and can't pass the validation

This fix it for get request